### PR TITLE
关于gstreamer-plugin 的qt扩展

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -6,6 +6,6 @@ PATCHPATH = "${CURDIR}/${BPN}_${MAJ_VER}"
 
 inherit auto-patch
 
-PACKAGECONFIG:remove = "qt5"
+#PACKAGECONFIG:remove = "qt5"
 
 DEPENDS:append = " rockchip-librga"


### PR DESCRIPTION
由于remove指令是最后阶段执行，所以无论其他layer的优先级如何，都不能再加上qt扩展，所以不能在这里直接使用remove去除