### PR TITLE
Add u-boot-rockchip patch to SRC_URI

### DIFF
--- a/recipes-bsp/u-boot/u-boot-rockchip.bb
+++ b/recipes-bsp/u-boot/u-boot-rockchip.bb
@@ -22,6 +22,7 @@ SRCREV_rkbin = "104659686b734ab041ef958c0abece1a250f48a4"
 SRC_URI = " \
 	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=u-boot; \
 	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=rkbin;name=rkbin;destsuffix=rkbin; \
+	file://0003-Revert-Makefile-enable-Werror-option.patch \
 "
 
 SRCREV_FORMAT = "default_rkbin"


### PR DESCRIPTION
Default u-boot from mirrors has `-Werror` flag,
that makes compiling raise error on warnings.

The patch is already in the repo since oct 2019 (c47d8ea), but it has never been used.