### PR TITLE
Add support nanopc-t6 manufactured by friendlyelec

### DIFF
--- a/conf/machine/rockchip-rk3588-nanopc-t6.conf
+++ b/conf/machine/rockchip-rk3588-nanopc-t6.conf
@@ -1,0 +1,18 @@
+#@TYPE: Machine
+#@NAME: RK3588 friendlyelec Nanopc-T6 board
+
+require conf/machine/include/rk3588.inc
+
+MACHINEOVERRIDES .= ":nanopct6"
+
+KBUILD_DEFCONFIG = "nanopi6_linux_defconfig"
+KERNEL_DEVICETREE = "rockchip/rk3588-nanopi6-rev01.dtb"
+
+UBOOT_MACHINE = "nanopi6_defconfig"
+
+RK_WIFIBT_FIRMWARES = " \
+"
+
+MACHINE_EXTRA_RRECOMMENDS:append = " \
+	linux-firmware-rtl8125 \
+"

--- a/recipes-bsp/rk-binary/rk-binary-native.bbappend
+++ b/recipes-bsp/rk-binary/rk-binary-native.bbappend
@@ -1,0 +1,8 @@
+# Nanopc-T6 support
+SRC_URI:nanopct6 = " \
+	git://github.com/friendlyarm/rkbin.git;protocol=https;nobranch=1;branch=nanopi6;name=rkbin \
+	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=tools;name=tools;destsuffix=git/extra \
+"
+
+SRCREV_rkbin:nanopct6 = "d4dd7145c2b99100b6f703805a7e84888df4967f"
+SRCREV_tools:nanopct6 = "1a32bc776af52494144fcef6641a73850cee628a"

--- a/recipes-bsp/u-boot/u-boot-nanopct6/0001-Change-default-bootargs.patch
+++ b/recipes-bsp/u-boot/u-boot-nanopct6/0001-Change-default-bootargs.patch
@@ -1,0 +1,82 @@
+From 1016d877f0b2d9bee7a871053000eab6158ab51d Mon Sep 17 00:00:00 2001
+From: wata2ki <wata2ki@gmail.com>
+Date: Fri, 2 Jun 2023 00:41:36 +0900
+Subject: [PATCH 1/2] Change default bootargs
+
+Signed-off-by: wata2ki <wata2ki@gmail.com>
+---
+ arch/arm/mach-rockchip/boot_rkimg.c | 51 +----------------------------
+ 1 file changed, 1 insertion(+), 50 deletions(-)
+
+diff --git a/arch/arm/mach-rockchip/boot_rkimg.c b/arch/arm/mach-rockchip/boot_rkimg.c
+index 5802a97..3eeea26 100644
+--- a/arch/arm/mach-rockchip/boot_rkimg.c
++++ b/arch/arm/mach-rockchip/boot_rkimg.c
+@@ -131,7 +131,6 @@ finish:
+ static int get_bootdev_type(void)
+ {
+ 	char *boot_media = NULL, *devtype = NULL;
+-	char boot_options[128] = {0};
+ 	static int appended;
+ 	ulong devnum = 0;
+ 	int type = 0;
+@@ -179,55 +178,7 @@ static int get_bootdev_type(void)
+ 	if (!appended && boot_media) {
+ 		appended = 1;
+ 
+-	/*
+-	 * The legacy rockchip Android (SDK < 8.1) requires "androidboot.mode="
+-	 * to be "charger" or boot media which is a rockchip private solution.
+-	 *
+-	 * The official Android rule (SDK >= 8.1) is:
+-	 * "androidboot.mode=normal" or "androidboot.mode=charger".
+-	 *
+-	 * Now that this U-Boot is usually working with higher version
+-	 * Android (SDK >= 8.1), we follow the official rules.
+-	 *
+-	 * Common: androidboot.mode=charger has higher priority, don't override;
+-	 */
+-#ifdef CONFIG_RKIMG_ANDROID_BOOTMODE_LEGACY
+-		/* rknand doesn't need "androidboot.mode="; */
+-		if (env_exist("bootargs", "androidboot.mode=charger") ||
+-		    (type == IF_TYPE_RKNAND) ||
+-		    (type == IF_TYPE_SPINAND) ||
+-		    (type == IF_TYPE_SPINOR))
+-			snprintf(boot_options, sizeof(boot_options),
+-				 "storagemedia=%s", boot_media);
+-		else
+-			snprintf(boot_options, sizeof(boot_options),
+-				 "storagemedia=%s androidboot.mode=%s",
+-				 boot_media, boot_media);
+-#else
+-		/*
+-		 * 1. "storagemedia": This is a legacy variable to indicate board
+-		 *    storage media for kernel and android.
+-		 *
+-		 * 2. "androidboot.storagemedia": The same purpose as "storagemedia",
+-		 *    but the android framework will auto create property by
+-		 *    variable with format "androidboot.xxx", eg:
+-		 *
+-		 *    "androidboot.storagemedia" => "ro.boot.storagemedia".
+-		 *
+-		 *    So, U-Boot pass this new variable is only for the convenience
+-		 *    to Android.
+-		 */
+-		if (env_exist("bootargs", "androidboot.mode=charger"))
+-			snprintf(boot_options, sizeof(boot_options),
+-				 "storagemedia=%s androidboot.storagemedia=%s",
+-				 boot_media, boot_media);
+-		else
+-			snprintf(boot_options, sizeof(boot_options),
+-				 "storagemedia=%s androidboot.storagemedia=%s "
+-				 "androidboot.mode=normal",
+-				 boot_media, boot_media);
+-#endif
+-		env_update("bootargs", boot_options);
++		env_update("bootargs", "console=ttyFIQ0 root=/dev/mmcblk0p3 rootwait rw ");
+ 	}
+ 
+ 	return type;
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot-nanopct6/0002-Disable-android-avb.patch
+++ b/recipes-bsp/u-boot/u-boot-nanopct6/0002-Disable-android-avb.patch
@@ -1,0 +1,26 @@
+From 439a1154199696d6b9ea6179d963b6013b4b6754 Mon Sep 17 00:00:00 2001
+From: wata2ki <wata2ki@gmail.com>
+Date: Fri, 2 Jun 2023 01:14:39 +0900
+Subject: [PATCH 2/2] Disable android avb
+
+Signed-off-by: wata2ki <wata2ki@gmail.com>
+---
+ configs/nanopi6_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configs/nanopi6_defconfig b/configs/nanopi6_defconfig
+index ce86b1e..c247390 100644
+--- a/configs/nanopi6_defconfig
++++ b/configs/nanopi6_defconfig
+@@ -33,7 +33,7 @@ CONFIG_BOOTDELAY=1
+ CONFIG_SYS_CONSOLE_INFO_QUIET=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ CONFIG_ANDROID_BOOTLOADER=y
+-CONFIG_ANDROID_AVB=y
++# CONFIG_ANDROID_AVB is not set
+ CONFIG_ANDROID_BOOT_IMAGE_HASH=y
+ CONFIG_SPL_BOARD_INIT=y
+ # CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
+-- 
+2.25.1
+

--- a/recipes-bsp/u-boot/u-boot-rockchip.bbappend
+++ b/recipes-bsp/u-boot/u-boot-rockchip.bbappend
@@ -1,0 +1,11 @@
+# Nanopc-T6 support
+FILESEXTRAPATHS:prepend := "${THISDIR}/u-boot-nanopct6:"
+
+SRCREV:nanopct6 = "93ceeb4da7efbabefe9b88b57093f90ea731d502"
+SRCREV_rkbin:nanopct6 = "d4dd7145c2b99100b6f703805a7e84888df4967f"
+SRC_URI:nanopct6 = " \
+	git://github.com/friendlyarm/uboot-rockchip.git;protocol=https;branch=nanopi6-v2017.09; \
+	git://github.com/friendlyarm/rkbin.git;protocol=https;branch=nanopi6;name=rkbin;destsuffix=rkbin; \
+	file://0001-Change-default-bootargs.patch \
+	file://0002-Disable-android-avb.patch \
+"

--- a/recipes-graphics/rockchip-libmali/rockchip-libmali.bb
+++ b/recipes-graphics/rockchip-libmali/rockchip-libmali.bb
@@ -79,6 +79,12 @@ do_install:append () {
 		sed -i 's/defined(MESA_EGL_NO_X11_HEADERS)/1/' \
 			${D}${includedir}/EGL/eglplatform.h
 	fi
+
+	if ${@bb.utils.contains('DISTRO_FEATURES', 'usrmerge', 'true', 'false', d)}; then
+		install -d ${D}${nonarch_base_libdir}/
+		mv ${D}/lib/firmware ${D}${nonarch_base_libdir}/
+		rm -rf ${D}/lib
+	fi
 }
 
 INSANE_SKIP:${PN} = "already-stripped ldflags dev-so textrel"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -16,12 +16,14 @@ SRC_URI:append = " \
 PACKAGES:prepend = " \
 	${PN}-rk-cdndp \
 	${PN}-rockchip-license \
+	${PN}-rtl8125 \
 "
 
 LICENSE:append = " & LICENSE.rockchip"
 LIC_FILES_CHKSUM:append = " file://${RKBASE}/licenses/LICENSE.rockchip;md5=d63890e209bf038f44e708bbb13e4ed9"
 LICENSE:${PN}-rk-cdndp = "LICENSE.rockchip"
 LICENSE:${PN}-rockchip-license = "LICENSE.rockchip"
+LICENSE:${PN}-rtl8125 = "WHENCE"
 
 FILES:${PN}-rockchip-license = " \
   ${nonarch_base_libdir}/firmware/LICENCE.rockchip \
@@ -29,7 +31,11 @@ FILES:${PN}-rockchip-license = " \
 FILES:${PN}-rk-cdndp = " \
   ${nonarch_base_libdir}/firmware/rockchip/dptx.bin \
 "
+FILES:${PN}-rtl8125 = " \
+  ${nonarch_base_libdir}/firmware/rtl_nic/rtl8125*.fw \
+"
 
 RDEPENDS:${PN}-rk-cdndp = "${PN}-rockchip-license"
+RDEPENDS:${PN}-rtl8125 = "${PN}-whence-license"
 
 INSANE_SKIP:append = " host-user-contaminated"

--- a/recipes-kernel/linux/linux-rockchip_5.10.bbappend
+++ b/recipes-kernel/linux/linux-rockchip_5.10.bbappend
@@ -1,0 +1,7 @@
+# Nanopc-T6 support
+
+SRC_URI:nanopct6 = " \
+	git://github.com/friendlyarm/kernel-rockchip.git;protocol=https;nobranch=1;branch=nanopi5-v5.10.y_opt; \
+	file://${THISDIR}/files/cgroups.cfg \
+"
+SRCREV:nanopct6 = "cb7d8763ec3827a1517ab0e3b7c6d744aba0d1e2"


### PR DESCRIPTION
I try to port Automotive Grade Linux for nanopc-t6 bord.  These patch are required to build Yocto.
If maintainer think fine, please merge these patch.