### PR TITLE
scarthgpa:  Update xserver-xorg_%.bbappend

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -4,7 +4,7 @@
 DEPENDS:append = " automake-native autoconf-native util-macros-native font-util-native xtrans-native libxshmfence rockchip-librga"
 
 SRCREV = "${AUTOREV}"
-SRC_URI:append = " git://github.com/JeffyCN/xorg-xserver;protocol=https;nobranch=1;branch=${PV}_2024_06_24;"
+SRC_URI:append = " git://github.com/JeffyCN/xorg-xserver;protocol=https;nobranch=1;branch=21.1.13;"
 SRC_URI:remove = "https://www.x.org/releases//individual/xserver/xorg-server-${PV}.tar.bz2"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
xserver-xorg in oe-core branch scarthgap was 21.1.14, but here bbappend for that was: ${PV}_2024_06_24.
error output:  Unable to resolve '21.1.14_2024_06_24' in upstream git repository in git ls-remote output for github.com/JeffyCN/xorg-xserver, so specify the 21.1.13 which was newest.