### PR TITLE
Fix afptool not found

### DIFF
--- a/recipes-bsp/rk-binary/rk-binary-native.bb
+++ b/recipes-bsp/rk-binary/rk-binary-native.bb
@@ -25,13 +25,13 @@ STRIP = "echo"
 UNINATIVE_LOADER := ""
 
 do_install () {
-	install -d ${D}/usr/bin/
+	install -d ${D}${bindir}
 
 	TOOLS="boot_merger trust_merger firmwareMerger kernelimage loaderimage \
 		mkkrnlimg resource_tool upgrade_tool afptool rkImageMaker"
 
 	for tool in ${TOOLS}; do
-		find ${S} -type f -name ${tool} -exec \
-			install -v -m 0755 {} ${D}/usr/bin/ \;
+		find ${S}/rkbin ${S}/tools/linux/Linux_Pack_Firmware/rockdev -type f -name ${tool} -exec \
+			install -v -m 0755 {} ${D}${bindir} \;
 	done
 }


### PR DESCRIPTION
This PR fixes an issue of `afptool: not found`, as described in this issue: https://github.com/JeffyCN/meta-rockchip/issues/149

There were two things necessary to fix:
1. `/usr/bin` != `${bindir}` -> it caused some `afptool` to not be found, as bitbake was looking for tools in wrong path. This can be seen exactly when `RM_WORK_EXCLUDE += " rk-binary-native"` is on and actual paths can be seen.
2. `afptool` is found in different locations within `JeffyCN/mirror.git`, cuasing wrong wersion of `afptool` to trigger sometimes, which also cause another explosion. Hardcoding to specific firectory with correct `afptool` solved the issue.

This PR basically rolls back the changes made to `rk-binary-native.bb` in https://github.com/JeffyCN/meta-rockchip/commit/ab0273aff95731deb1ae1bd9a52ac87b45722095