### PR TITLE
Add dependency to gstreamer1.0-rockchip if mpp enabled

### DIFF
--- a/recipes-multimedia/gstreamer-rockchip/gstreamer1.0-rockchip.bb
+++ b/recipes-multimedia/gstreamer-rockchip/gstreamer1.0-rockchip.bb
@@ -26,7 +26,7 @@ inherit meson pkgconfig
 
 PACKAGECONFIG ??= "mpp ${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)} rga kmssrc"
 
-PACKAGECONFIG[mpp] = "-Drockchipmpp=enabled,-Drockchipmpp=disabled,rockchip-mpp"
+PACKAGECONFIG[mpp] = "-Drockchipmpp=enabled,-Drockchipmpp=disabled,rockchip-mpp,${PN}-rockchipmpp"
 PACKAGECONFIG[x11] = "-Drkximage=enabled,-Drkximage=disabled,libx11 libdrm"
 PACKAGECONFIG[rga] = "-Drga=enabled,-Drga=disabled,rockchip-librga"
 PACKAGECONFIG[kmssrc] = "-Dkmssrc=enabled,-Dkmssrc=disabled,libdrm"


### PR DESCRIPTION
If PACKAGECONFIG contains 'mpp' we should pull the created package in as well. Add the parameter required.