### PR TITLE
fix rockchip-rkisp recipe

### DIFF
--- a/dynamic-layers/recipes-browser/chromium/chromium-%.bbappend
+++ b/dynamic-layers/recipes-browser/chromium/chromium-%.bbappend
@@ -10,6 +10,9 @@ PACKAGECONFIG[use-v4lplugin] = "use_v4lplugin=true"
 
 GN_ARGS:append = " fatal_linker_warnings=false"
 
+# Vulkan unsupported for now
+GN_ARGS:append = " enable_vulkan=false"
+
 CHROMIUM_EXTRA_ARGS:append = " --no-sandbox --gpu-sandbox-start-early --ignore-gpu-blocklist"
 
 # Enable VEA as well

--- a/recipes-multimedia/rockchip-rkisp/files/0001-fix-yocto-wrynose-errors.patch
+++ b/recipes-multimedia/rockchip-rkisp/files/0001-fix-yocto-wrynose-errors.patch
@@ -1,0 +1,38 @@
+From a1c3e232a305247f4551b2bc2a5f99b9ac5ae935 Mon Sep 17 00:00:00 2001
+From: Pieter Van Buggenhout <pieter.vanbuggenhout@camco.be>
+Date: Wed, 17 Jun 2026 09:59:13 +0200
+Subject: [PATCH] fix yocto wrynose errors
+
+---
+ ext/tinyxml2/tinyxml2.h      | 2 +-
+ gstreamer/media-controller.c | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/ext/tinyxml2/tinyxml2.h b/ext/tinyxml2/tinyxml2.h
+index 8cabd0c6bdd0..16b3c2841091 100644
+--- a/ext/tinyxml2/tinyxml2.h
++++ b/ext/tinyxml2/tinyxml2.h
+@@ -162,7 +162,7 @@ template <class T, int INIT>
+ class DynArray
+ {
+ public:
+-    DynArray< T, INIT >()
++    DynArray()
+     {
+         mem = pool;
+         allocated = INIT;
+diff --git a/gstreamer/media-controller.c b/gstreamer/media-controller.c
+index cce5623ef188..1d4bf7b1ea1b 100644
+--- a/gstreamer/media-controller.c
++++ b/gstreamer/media-controller.c
+@@ -20,6 +20,7 @@
+  */
+ #include "media-controller.h"
+ 
++#include <string.h>
+ #include <fcntl.h>
+ #include <unistd.h>
+ #include <stdio.h>
+-- 
+2.53.0
+

--- a/recipes-multimedia/rockchip-rkisp/rockchip-rkisp.bb
+++ b/recipes-multimedia/rockchip-rkisp/rockchip-rkisp.bb
@@ -17,12 +17,15 @@ inherit local-git
 SRCREV = "fafcd69874d20a7737425cc16a70619b220f8a2e"
 SRC_URI = " \
 	git://github.com/JeffyCN/mirrors.git;protocol=https;branch=camera_engine_rkisp; \
+	file://0001-fix-yocto-wrynose-errors.patch \
 	file://rkisp_daemons.sh \
 "
 
 EXTRA_OECMAKE = " \
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 "
+
+CFLAGS:append = " -D_GNU_SOURCE"
 
 do_configure() {
 	if echo ${TUNE_FEATURES} | grep -wq arm; then
@@ -98,7 +101,10 @@ INITSCRIPT_PACKAGES = "${PN}-server"
 INITSCRIPT_NAME:${PN}-server = "rkisp_daemons.sh"
 INITSCRIPT_PARAMS:${PN}-server = "start 70 5 4 3 2 . stop 30 0 1 6 ."
 
-INSANE_SKIP:${PN} = "already-stripped ldflags"
+INSANE_SKIP:${PN} = "already-stripped ldflags buildpaths"
+INSANE_SKIP:${PN}-dbg += "buildpaths"
+INSANE_SKIP:${PN}-tests += "buildpaths"
+INSANE_SKIP:${PN}-server += "buildpaths"
 
 FILES:${PN}-dev = "${includedir}"
 FILES:${PN}-tests = "${bindir}/rkisp_demo"


### PR DESCRIPTION
Hi @JeffyCN 

The `rockchip-rkisp` recipe fails for me on Ubuntu 26.04 wrynose.
Specifically the `do_compile` and `do_package` steps.

I got a fix but I am not sure if this is the right way to go.
I would love to hear your thoughts.

**Compile**

1)
```c
| [module] metadata
| make[2]: Entering directory '/media/ssdb/bitbake-builds/camos-wrynose/build/tmp/work/cortexa76-cortexa55-camos-linux/rockchip-rkisp/1.0/sources/rockchip-rkisp-1.0/metadata'
| libcamera_metadata/src/camera_metadata.c: In function 'dump_indented_camera_metadata':
| libcamera_metadata/src/camera_metadata.c:907:9: error: implicit declaration of function 'dprintf'; did you mean 'vprintf'? [-Wimplicit-function-declaration]
|   907 |         dprintf(fd, "%*sDumping camera metadata array: Not allocated\n",
|       |         ^~~~~~~
|       |         vprintf
```
Fixed by adding `-D_GNU_SOURCE`

2)
```c
| /media/ssdb/bitbake-builds/camos-wrynose/build/tmp/work/cortexa76-cortexa55-camos-linux/rockchip-rkisp/1.0/sources/rockchip-rkisp-1.0/rkisp/ia-engine/calib_xml/../../../ext/tinyxml2/tinyxml2.h:165:24: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
|   165 |     DynArray< T, INIT >()
```
Fixed by removing `< T, INIT >` (already specified in class definition) `template <class T, int INIT> class DynArray`

3)
```c
make[2]: Entering directory '/media/ssdb/bitbake-builds/camos-wrynose/build/tmp/work/cortexa76-cortexa55-camos-linux/rockchip-rkisp/1.0/sources/rockchip-rkisp-1.0/gstreamer'
media-controller.c: In function 'gst_media_controller_new_by_vnode':
media-controller.c:56:14: error: implicit declaration of function 'strcmp' [-Wimplicit-function-declaration]
   56 |         if (!strcmp (devname, vnode)) {
      |              ^~~~~~
media-controller.c:27:1: note: include '<string.h>' or provide a declaration of 'strcmp'
   26 | #include <stdlib.h>
  +++ |+#include <string.h>
   27 | 
```
Fixed by adding `#include <string.h>` as suggested

**Package**

```
ERROR: rockchip-rkisp-1.0-r0 do_package_qa: QA Issue: File /usr/bin/rkisp_demo in package rockchip-rkisp-tests contains reference to TMPDIR [buildpaths]
ERROR: rockchip-rkisp-1.0-r0 do_package_qa: QA Issue: File /usr/lib/librkisp.so in package rockchip-rkisp contains reference to TMPDIR [buildpaths]
ERROR: rockchip-rkisp-1.0-r0 do_package_qa: QA Issue: File /usr/lib/.debug/librkisp.so in package rockchip-rkisp-dbg contains reference to TMPDIR [buildpaths]
ERROR: rockchip-rkisp-1.0-r0 do_package_qa: QA Issue: File /usr/bin/rkisp_3A_server in package rockchip-rkisp-server contains reference to TMPDIR [buildpaths]
ERROR: rockchip-rkisp-1.0-r0 do_package_qa: Fatal QA errors were found, failing task.
```
Some host specific paths are compiled into the binaries:
```
$ strings rkisp_3A_server | grep /media/ssdb/
/media/ssdb/bitbake-builds/camos-wrynose/build/tmp/work/cortexa76-cortexa55-camos-linux/rockchip-rkisp/1.0/sources/rockchip-rkisp-1.0/build/ext/rkisp/usr/lib:/media/ssdb/bitbake-builds/camos-wrynose/build/tmp/work/cortexa76-cortexa55-camos-linux/rockchip-rkisp/1.0/sources/rockchip-rkisp-1.0/build/ext/rkisp/usr/lib/gstreamer-1.0

$ strings rkisp_demo | grep /media/ssdb/
/media/ssdb/bitbake-builds/camos-wrynose/build/tmp/work/cortexa76-cortexa55-camos-linux/rockchip-rkisp/1.0/sources/rockchip-rkisp-1.0/build/ext/rkisp/usr/lib:/media/ssdb/bitbake-builds/camos-wrynose/build/tmp/work/cortexa76-cortexa55-camos-linux/rockchip-rkisp/1.0/sources/rockchip-rkisp-1.0/build/ext/rkisp/usr/lib/gstreamer-1.0
/media/ssdb/bitbake-builds/camos-wrynose/build/tmp/work/cortexa76-cortexa55-camos-linux/rockchip-rkisp/1.0/sources/rockchip-rkisp-1.0/apps/rkisp_demo/../../xcore/xcam_mutex.h
```
Fixed by adding
```bitbake
INSANE_SKIP:${PN} += "buildpaths"
INSANE_SKIP:${PN}-dbg += "buildpaths"
INSANE_SKIP:${PN}-tests += "buildpaths"
INSANE_SKIP:${PN}-server += "buildpaths"
```