### PR TITLE
weston: Remove upstreamed touch-calibrator patch

### DIFF
--- a/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-graphics/wayland/weston_%.bbappend
@@ -10,3 +10,8 @@ S = "${WORKDIR}/git"
 
 # The custom player demo depends on gstreamer.
 DEPENDS:append = " ${@bb.utils.contains('PACKAGECONFIG', 'clients', 'gstreamer1.0-plugins-base', '', d)}"
+
+# in weston 14 the touch-calibrator patch is no longer needed (yocto 5.0.18 provides weston 13)
+SRC_URI:remove = " \
+    file://0001-touch-calibrator-Regularise-surface-view-mapping.patch \
+"


### PR DESCRIPTION
In weston 14 the touch-calibrator patch is no longer needed (yocto 5.0.18 provides weston 13)

Compiled with

```
yocto 5.0.18

meta                 
meta-poky            
meta-yocto-bsp       = "HEAD:44dcf08572ce391d7c0df4f8c7510af5e096baca"

meta-oe              
meta-networking      
meta-multimedia      
meta-python          
meta-webserver       = "HEAD:d8cc4e44001c7257273d290ce8c4496e93d32841"

meta-clang           = "HEAD:76596813cd0061bd9818a80926e6900af61fcaa0"
meta-lts-mixins-rust = "HEAD:96deb45139df027473faf0938fe006d33c45c375"
meta-chromium        = "HEAD:d4c6ed09cd724c25648f6cb4a02a350d7423a5a1"
```

Note: I've pointed meta-browser (meta-chromium) to a version that has chromium 138