### PR TITLE
chromium: Support 138.0.7204

### DIFF
--- a/dynamic-layers/recipes-browser/chromium/chromium-ozone-wayland_%.bbappend
+++ b/dynamic-layers/recipes-browser/chromium/chromium-ozone-wayland_%.bbappend
@@ -2,3 +2,19 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 CHROMIUM_EXTRA_ARGS:append = " --enable-wayland-ime"
+
+# redefining do_copy_target_rustlibs to fix duplicates from rust-cross vs 
+# libstd-rs causing symbol hash mismatches at link time.
+do_copy_target_rustlibs () {
+    # Chromium needs a single Rust sysroot that contains the rustlibs for both
+    # the host and target, so we copy the target rustlibs to the native sysroot.
+    # Remove old rlibs/rmeta first to avoid duplicates from rust-cross vs
+    # libstd-rs causing symbol hash mismatches at link time.
+    # Use RUST_TARGET_SYS (not TARGET_ARCH*) to avoid nuking host rlibs.
+    rustlib_src_dir="${STAGING_LIBDIR}/rustlib/${TARGET_ARCH}"*
+    if [ -d "${STAGING_LIBDIR_NATIVE}/rustlib/${RUST_TARGET_SYS}/lib" ]; then
+        rm -f "${STAGING_LIBDIR_NATIVE}/rustlib/${RUST_TARGET_SYS}/lib"/*.rlib
+        rm -f "${STAGING_LIBDIR_NATIVE}/rustlib/${RUST_TARGET_SYS}/lib"/*.rmeta
+    fi
+    cp -r $rustlib_src_dir "${STAGING_LIBDIR_NATIVE}/rustlib"
+}

--- a/dynamic-layers/recipes-browser/chromium/chromium-x11_%.bbappend
+++ b/dynamic-layers/recipes-browser/chromium/chromium-x11_%.bbappend
@@ -2,3 +2,19 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 DEPENDS:append = " libxshmfence libxkbcommon"
+
+# redefining do_copy_target_rustlibs to fix duplicates from rust-cross vs 
+# libstd-rs causing symbol hash mismatches at link time.
+do_copy_target_rustlibs () {
+    # Chromium needs a single Rust sysroot that contains the rustlibs for both
+    # the host and target, so we copy the target rustlibs to the native sysroot.
+    # Remove old rlibs/rmeta first to avoid duplicates from rust-cross vs
+    # libstd-rs causing symbol hash mismatches at link time.
+    # Use RUST_TARGET_SYS (not TARGET_ARCH*) to avoid nuking host rlibs.
+    rustlib_src_dir="${STAGING_LIBDIR}/rustlib/${TARGET_ARCH}"*
+    if [ -d "${STAGING_LIBDIR_NATIVE}/rustlib/${RUST_TARGET_SYS}/lib" ]; then
+        rm -f "${STAGING_LIBDIR_NATIVE}/rustlib/${RUST_TARGET_SYS}/lib"/*.rlib
+        rm -f "${STAGING_LIBDIR_NATIVE}/rustlib/${RUST_TARGET_SYS}/lib"/*.rmeta
+    fi
+    cp -r $rustlib_src_dir "${STAGING_LIBDIR_NATIVE}/rustlib"
+}

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0001-HACK-media-Support-V4L2-video-decoder.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0001-HACK-media-Support-V4L2-video-decoder.patch
@@ -1,0 +1,563 @@
+From cc324c8c0b6184fb1a718b793d9d207804b3df85 Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Thu, 14 Dec 2023 10:00:22 +0800
+Subject: [PATCH 01/16] HACK: media: Support V4L2 video decoder
+
+Tested on RK3588 EVB with:
+1/ Install libmali, v4l-rkmpp, mpp and custom v4l-utils.
+2/ Run "echo dec > /dev/video-dec0"
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/media/gpu/chromeos/fourcc.cc b/media/gpu/chromeos/fourcc.cc
+--- a/media/gpu/chromeos/fourcc.cc
++++ b/media/gpu/chromeos/fourcc.cc
+@@ -357,10 +357,14 @@
+ static_assert(Fourcc::NM21 == V4L2_PIX_FMT_NV21M, "Mismatch Fourcc");
+ static_assert(Fourcc::YU16 == V4L2_PIX_FMT_YUV422P, "Mismatch Fourcc");
+ static_assert(Fourcc::YM16 == V4L2_PIX_FMT_YUV422M, "Mismatch Fourcc");
++#if defined(V4L2_PIX_FMT_MM21) && defined(V4L2_PIX_FMT_MT21C)
+ static_assert(Fourcc::MM21 == V4L2_PIX_FMT_MM21, "Mismatch Fourcc");
+ static_assert(Fourcc::MT21 == V4L2_PIX_FMT_MT21C, "Mismatch Fourcc");
++#endif
+ static_assert(Fourcc::AR24 == V4L2_PIX_FMT_ABGR32, "Mismatch Fourcc");
++#ifdef V4L2_PIX_FMT_P010
+ static_assert(Fourcc::P010 == V4L2_PIX_FMT_P010, "Mismatch Fourcc");
++#endif
+ // MT2T has not been upstreamed yet
+ #ifdef V4L2_PIX_FMT_MT2T
+ static_assert(Fourcc::MT2T == V4L2_PIX_FMT_MT2T, "Mismatch Fourcc");
+
+diff --git a/media/gpu/chromeos/fourcc.h b/media/gpu/chromeos/fourcc.h
+--- a/media/gpu/chromeos/fourcc.h
++++ b/media/gpu/chromeos/fourcc.h
+@@ -14,6 +14,18 @@
+ #include "media/gpu/buildflags.h"
+ #include "media/gpu/media_gpu_export.h"
+ 
++#ifndef V4L2_PIX_FMT_MT21C
++#define V4L2_PIX_FMT_MT21C	v4l2_fourcc('M', 'T', '2', '1') /* Mediatek compressed block mode  */
++#endif
++
++#ifndef V4L2_PIX_FMT_VP9
++#define V4L2_PIX_FMT_VP9	v4l2_fourcc('V', 'P', '9', '0') /* VP9 */
++#endif
++
++#ifndef V4L2_PIX_FMT_HEVC
++#define V4L2_PIX_FMT_HEVC	v4l2_fourcc('H', 'E', 'V', 'C') /* HEVC */
++#endif
++
+ namespace media {
+ 
+ // Composes a Fourcc value.
+
+diff --git a/media/gpu/v4l2/BUILD.gn b/media/gpu/v4l2/BUILD.gn
+--- a/media/gpu/v4l2/BUILD.gn
++++ b/media/gpu/v4l2/BUILD.gn
+@@ -42,34 +42,37 @@
+     "v4l2_video_decoder.h",
+     "v4l2_video_decoder_backend.cc",
+     "v4l2_video_decoder_backend.h",
+-    "v4l2_video_decoder_backend_stateless.cc",
+-    "v4l2_video_decoder_backend_stateless.h",
+-    "v4l2_video_decoder_delegate_h264.cc",
+-    "v4l2_video_decoder_delegate_h264.h",
+-    "v4l2_video_decoder_delegate_vp8.cc",
+-    "v4l2_video_decoder_delegate_vp8.h",
+-    "v4l2_video_decoder_delegate_vp9.cc",
+-    "v4l2_video_decoder_delegate_vp9.h",
+     "v4l2_vp9_helpers.cc",
+     "v4l2_vp9_helpers.h",
+   ]
+ 
+-  if (enable_hevc_parser_and_hw_decoder) {
++  if (is_chromeos) {
+     sources += [
+-      "v4l2_video_decoder_delegate_h265.cc",
+-      "v4l2_video_decoder_delegate_h265.h",
++      "v4l2_video_decoder_backend_stateless.cc",
++      "v4l2_video_decoder_backend_stateless.h",
++      "v4l2_video_decoder_delegate_h264.cc",
++      "v4l2_video_decoder_delegate_h264.h",
++      "v4l2_video_decoder_delegate_vp8.cc",
++      "v4l2_video_decoder_delegate_vp8.h",
++      "v4l2_video_decoder_delegate_vp9.cc",
++      "v4l2_video_decoder_delegate_vp9.h",
+     ]
+-  }
+ 
+-  if (current_cpu == "arm" || current_cpu == "arm64") {
+-    sources += [
+-      "mt21/mt21_decompressor.cc",
+-      "mt21/mt21_decompressor.h",
+-      "mt21/mt21_util.h",
+-    ]
+-  }
++    if (enable_hevc_parser_and_hw_decoder) {
++      sources += [
++        "v4l2_video_decoder_delegate_h265.cc",
++        "v4l2_video_decoder_delegate_h265.h",
++      ]
++    }
++
++    if (current_cpu == "arm" || current_cpu == "arm64") {
++      sources += [
++        "mt21/mt21_decompressor.cc",
++        "mt21/mt21_decompressor.h",
++        "mt21/mt21_util.h",
++      ]
++    }
+ 
+-  if (is_chromeos) {
+     sources += [
+       # AV1 delegate depends on header files only in ChromeOS SDK
+       "v4l2_video_decoder_delegate_av1.cc",
+
+diff --git a/media/gpu/v4l2/legacy/v4l2_video_decode_accelerator.h b/media/gpu/v4l2/legacy/v4l2_video_decode_accelerator.h
+--- a/media/gpu/v4l2/legacy/v4l2_video_decode_accelerator.h
++++ b/media/gpu/v4l2/legacy/v4l2_video_decode_accelerator.h
+@@ -20,7 +20,7 @@
+ 
+ #include "build/build_config.h"
+ 
+-#if defined(ARCH_CPU_ARM_FAMILY)
++#if defined(ARCH_CPU_ARM_FAMILY) && BUILDFLAG(IS_CHROMEOS)
+ // The MT21C software decompressor is tightly coupled to the MT8173.
+ // See mt21_decompressor.h
+ #define SUPPORT_MT21_PIXEL_FORMAT_SOFTWARE_DECOMPRESSION
+
+diff --git a/media/gpu/v4l2/legacy/v4l2_video_decoder_backend_stateful.cc b/media/gpu/v4l2/legacy/v4l2_video_decoder_backend_stateful.cc
+--- a/media/gpu/v4l2/legacy/v4l2_video_decoder_backend_stateful.cc
++++ b/media/gpu/v4l2/legacy/v4l2_video_decoder_backend_stateful.cc
+@@ -759,6 +759,7 @@
+   DCHECK(device_);
+   if (supported_profiles_.empty()) {
+     const std::vector<uint32_t> kSupportedInputFourccs = {
++        V4L2_PIX_FMT_AV1,
+         V4L2_PIX_FMT_H264,
+         V4L2_PIX_FMT_VP8,
+         V4L2_PIX_FMT_VP9,
+
+diff --git a/media/gpu/v4l2/v4l2_device.cc b/media/gpu/v4l2/v4l2_device.cc
+--- a/media/gpu/v4l2/v4l2_device.cc
++++ b/media/gpu/v4l2/v4l2_device.cc
+@@ -376,7 +376,8 @@
+   if (HANDLE_EINTR(write(device_poll_interrupt_fd_.get(), &buf, sizeof(buf))) ==
+       -1) {
+     VPLOGF(1) << "write() failed";
+-    return false;
++    // HACK: Fake success for eventfd
++    // return false;
+   }
+   return true;
+ }
+@@ -392,7 +393,8 @@
+       return true;
+     } else {
+       VPLOGF(1) << "read() failed";
+-      return false;
++      // HACK: Fake success for eventfd
++      // return false;
+     }
+   }
+   return true;
+@@ -855,7 +857,8 @@
+ }
+ 
+ void V4L2Device::EnumerateDevicesForType(Type type) {
+-#if BUILDFLAG(IS_CHROMEOS)
++// HACK: We are using chromeos style devices.
++#if 1 //BUILDFLAG(IS_CHROMEOS)
+   static const std::string kDecoderDevicePattern = "/dev/video-dec";
+   static const std::string kEncoderDevicePattern = "/dev/video-enc";
+   static const std::string kImageProcessorDevicePattern = "/dev/image-proc";
+
+diff --git a/media/gpu/v4l2/v4l2_queue.cc b/media/gpu/v4l2/v4l2_queue.cc
+--- a/media/gpu/v4l2/v4l2_queue.cc
++++ b/media/gpu/v4l2/v4l2_queue.cc
+@@ -1072,10 +1072,14 @@
+       weak_this_factory_(this) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+ 
++#if BUILDFLAG(IS_CHROMEOS)
+   struct v4l2_requestbuffers reqbufs = {
+       .count = 0, .type = type_, .memory = V4L2_MEMORY_MMAP};
+   supports_requests_ = (ioctl_cb_.Run(VIDIOC_REQBUFS, &reqbufs) == kIoctlOk) &&
+                        (reqbufs.capabilities & V4L2_BUF_CAP_SUPPORTS_REQUESTS);
++#else
++  supports_requests_ = false;
++#endif
+ 
+   // Stateful backends for example do not support requests.
+   VPLOG_IF(4, supports_requests_)
+@@ -1192,6 +1196,7 @@
+   planes_count_ = format->fmt.pix_mp.num_planes;
+   DCHECK_LE(planes_count_, static_cast<size_t>(VIDEO_MAX_PLANES));
+ 
++#if BUILDFLAG(IS_CHROMEOS)
+   __u8 flags = incoherent ? V4L2_MEMORY_FLAG_NON_COHERENT : 0;
+   if (allocate_secure_cb_) {
+     flags |= V4L2_MEMORY_FLAG_RESTRICTED;
+@@ -1203,6 +1208,13 @@
+       .flags = flags};
+   DVQLOGF(3) << "Requesting " << count << " buffers ("
+              << (incoherent ? "incoherent" : "coherent") << ")";
++#else
++  struct v4l2_requestbuffers reqbufs = {
++      .count = base::checked_cast<decltype(v4l2_requestbuffers::count)>(count),
++      .type = type_,
++      .memory = memory};
++  DVQLOGF(3) << "Requesting " << count << " buffers";
++#endif
+ 
+   int ret = ioctl_cb_.Run(VIDIOC_REQBUFS, &reqbufs);
+   if (ret) {
+@@ -1268,12 +1280,17 @@
+   secure_buffers_.clear();
+ 
+   // Free all buffers.
++#if BUILDFLAG(IS_CHROMEOS)
+   __u8 flags = incoherent_ ? V4L2_MEMORY_FLAG_NON_COHERENT : 0;
+   if (allocate_secure_cb_) {
+     flags |= V4L2_MEMORY_FLAG_RESTRICTED;
+   }
+   struct v4l2_requestbuffers reqbufs = {
+       .count = 0, .type = type_, .memory = memory_, .flags = flags};
++#else
++  struct v4l2_requestbuffers reqbufs = {
++      .count = 0, .type = type_, .memory = memory_};
++#endif
+ 
+   int ret = ioctl_cb_.Run(VIDIOC_REQBUFS, &reqbufs);
+   if (ret) {
+@@ -1593,6 +1610,8 @@
+     uint64_t modifier,
+     const gfx::Size& size) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++
++#if BUILDFLAG(IS_CHROMEOS)
+   if (DRM_FORMAT_MOD_QCOM_COMPRESSED == modifier) {
+     auto format = SetFormat(V4L2_PIX_FMT_QC08C, size, 0);
+ 
+@@ -1601,6 +1620,7 @@
+     }
+     return format;
+   }
++#endif
+   return std::nullopt;
+ }
+ 
+@@ -1712,6 +1732,7 @@
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   DCHECK_NE(ctrls, nullptr);
+ 
++#if BUILDFLAG(IS_CHROMEOS)
+   if (!request_fd_.is_valid()) {
+     VPLOGF(1) << "Invalid request";
+     return false;
+@@ -1721,12 +1742,16 @@
+   ctrls->request_fd = request_fd_.get();
+ 
+   return true;
++#else
++  return false;
++#endif
+ }
+ 
+ bool V4L2Request::ApplyQueueBuffer(struct v4l2_buffer* buffer) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   DCHECK_NE(buffer, nullptr);
+ 
++#if BUILDFLAG(IS_CHROMEOS)
+   if (!request_fd_.is_valid()) {
+     VPLOGF(1) << "Invalid request";
+     return false;
+@@ -1736,11 +1761,15 @@
+   buffer->request_fd = request_fd_.get();
+ 
+   return true;
++#else
++  return false;
++#endif
+ }
+ 
+ bool V4L2Request::Submit() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+ 
++#if BUILDFLAG(IS_CHROMEOS)
+   if (!request_fd_.is_valid()) {
+     VPLOGF(1) << "No valid request file descriptor to submit request.";
+     return false;
+@@ -1752,6 +1781,9 @@
+   }
+ 
+   return true;
++#else
++  return false;
++#endif
+ }
+ 
+ bool V4L2Request::IsCompleted() {
+@@ -1788,6 +1820,7 @@
+ bool V4L2Request::Reset() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+ 
++#if BUILDFLAG(IS_CHROMEOS)
+   if (!request_fd_.is_valid()) {
+     VPLOGF(1) << "Invalid request";
+     return false;
+@@ -1801,6 +1834,9 @@
+   }
+ 
+   return true;
++#else
++  return false;
++#endif
+ }
+ 
+ V4L2RequestRefBase::V4L2RequestRefBase(V4L2RequestRefBase&& req_base) {
+@@ -1877,6 +1913,7 @@
+ std::optional<base::ScopedFD> V4L2RequestsQueue::CreateRequestFD() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+ 
++#if BUILDFLAG(IS_CHROMEOS)
+   int request_fd;
+   int ret = HANDLE_EINTR(
+       ioctl(media_fd_.get(), MEDIA_IOC_REQUEST_ALLOC, &request_fd));
+@@ -1887,11 +1924,15 @@
+   }
+ 
+   return base::ScopedFD(request_fd);
++#else
++  return std::nullopt;
++#endif
+ }
+ 
+ std::optional<V4L2RequestRef> V4L2RequestsQueue::GetFreeRequest() {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+ 
++#if BUILDFLAG(IS_CHROMEOS)
+   V4L2Request* request_ptr =
+       free_requests_.empty() ? nullptr : free_requests_.front();
+   if (request_ptr && request_ptr->IsCompleted()) {
+@@ -1929,6 +1970,9 @@
+   }
+ 
+   return V4L2RequestRef(request_ptr);
++#else
++  return std::nullopt;
++#endif
+ }
+ 
+ void V4L2RequestsQueue::ReturnRequest(V4L2Request* request) {
+
+diff --git a/media/gpu/v4l2/v4l2_utils.cc b/media/gpu/v4l2/v4l2_utils.cc
+--- a/media/gpu/v4l2/v4l2_utils.cc
++++ b/media/gpu/v4l2/v4l2_utils.cc
+@@ -46,6 +46,19 @@
+ #define MAKE_V4L2_CODEC_PAIR(codec, suffix) \
+   std::make_pair(codec##_##suffix, codec)
+ 
++#ifndef V4L2_CID_MPEG_VIDEO_AV1_PROFILE
++#ifdef V4L2_CID_CODEC_BASE
++#define V4L2_CID_MPEG_VIDEO_AV1_PROFILE (V4L2_CID_CODEC_BASE + 655)
++#else
++#define V4L2_CID_MPEG_VIDEO_AV1_PROFILE (V4L2_CID_MPEG_BASE + 655)
++#endif
++enum v4l2_mpeg_video_av1_profile {
++       V4L2_MPEG_VIDEO_AV1_PROFILE_MAIN = 0,
++       V4L2_MPEG_VIDEO_AV1_PROFILE_HIGH = 1,
++       V4L2_MPEG_VIDEO_AV1_PROFILE_PROFESSIONAL = 2,
++};
++#endif
++
+ namespace {
+ int HandledIoctl(int fd, int request, void* arg) {
+   return HANDLE_EINTR(ioctl(fd, request, arg));
+@@ -205,7 +218,6 @@
+       }
+       break;
+ #endif
+-#if BUILDFLAG(IS_CHROMEOS)
+     case V4L2_CID_MPEG_VIDEO_AV1_PROFILE:
+       switch (v4l2_profile) {
+         case V4L2_MPEG_VIDEO_AV1_PROFILE_MAIN:
+@@ -216,7 +228,6 @@
+           return AV1PROFILE_PROFILE_PRO;
+       }
+       break;
+-#endif
+   }
+   return VIDEO_CODEC_PROFILE_UNKNOWN;
+ }
+@@ -337,10 +348,8 @@
+         {V4L2_PIX_FMT_VP8_FRAME, V4L2_CID_MPEG_VIDEO_VP8_PROFILE},
+         {V4L2_PIX_FMT_VP9, V4L2_CID_MPEG_VIDEO_VP9_PROFILE},
+         {V4L2_PIX_FMT_VP9_FRAME, V4L2_CID_MPEG_VIDEO_VP9_PROFILE},
+-#if BUILDFLAG(IS_CHROMEOS)
+         {V4L2_PIX_FMT_AV1, V4L2_CID_MPEG_VIDEO_AV1_PROFILE},
+         {V4L2_PIX_FMT_AV1_FRAME, V4L2_CID_MPEG_VIDEO_AV1_PROFILE},
+-#endif
+ };
+ 
+ // Default VideoCodecProfiles associated to a V4L2 Codec Control ID.
+@@ -358,9 +367,7 @@
+ #endif  // BUILDFLAG(ENABLE_HEVC_PARSER_AND_HW_DECODER)
+         {V4L2_CID_MPEG_VIDEO_VP8_PROFILE, {VP8PROFILE_ANY}},
+         {V4L2_CID_MPEG_VIDEO_VP9_PROFILE, {VP9PROFILE_PROFILE0}},
+-#if BUILDFLAG(IS_CHROMEOS)
+         {V4L2_CID_MPEG_VIDEO_AV1_PROFILE, {AV1PROFILE_PROFILE_MAIN}},
+-#endif
+ };
+ 
+ // Correspondence from a VideoCodecProfiles to V4L2 codec described
+@@ -378,10 +385,8 @@
+         {VP8PROFILE_ANY, MAKE_V4L2_CODEC_PAIR(V4L2_PIX_FMT_VP8, FRAME)},
+         {VP9PROFILE_PROFILE0, MAKE_V4L2_CODEC_PAIR(V4L2_PIX_FMT_VP9, FRAME)},
+         {VP9PROFILE_PROFILE2, MAKE_V4L2_CODEC_PAIR(V4L2_PIX_FMT_VP9, FRAME)},
+-#if BUILDFLAG(IS_CHROMEOS)
+         {AV1PROFILE_PROFILE_MAIN,
+          MAKE_V4L2_CODEC_PAIR(V4L2_PIX_FMT_AV1, FRAME)},
+-#endif
+ };
+ 
+ }  // namespace
+@@ -547,6 +552,13 @@
+   CHECK(base::Contains(kVideoCodecProfileToV4L2CodecPixFmt, profile))
+       << "Unsupported profile: " << GetProfileName(profile);
+ 
++#if !BUILDFLAG(IS_CHROMEOS)
++  if (slice_based) {
++    LOG(ERROR) << "Slice is not supported";
++    return 0;
++  }
++#endif
++
+   const auto& v4l2_pix_fmt = kVideoCodecProfileToV4L2CodecPixFmt.at(profile);
+   return slice_based ? v4l2_pix_fmt.first : v4l2_pix_fmt.second;
+ }
+@@ -571,7 +583,8 @@
+   SupportedVideoDecoderConfigs supported_media_configs;
+   std::vector<std::string> candidate_paths;
+ 
+-#if BUILDFLAG(IS_CHROMEOS)
++// HACK: We are using chromeos style devices.
++#if 1 //BUILDFLAG(IS_CHROMEOS)
+   constexpr char kVideoDevicePattern[] = "/dev/video-dec0";
+   candidate_paths.push_back(kVideoDevicePattern);
+ #else
+@@ -632,6 +645,7 @@
+ }
+ 
+ bool IsV4L2DecoderStateful() {
++#if 0
+   constexpr char kVideoDeviceDriverPath[] = "/dev/video-dec0";
+   base::ScopedFD device_fd(HANDLE_EINTR(
+       open(kVideoDeviceDriverPath, O_RDWR | O_NONBLOCK | O_CLOEXEC)));
+@@ -654,6 +668,10 @@
+                             kSupportedStatefulInputCodecs.begin(),
+                             kSupportedStatefulInputCodecs.end()) !=
+          v4l2_codecs.end();
++#else
++  /* HACK: Force disabling stateful decoder. */
++  return false;
++#endif
+ }
+ 
+ bool IsVislDriver() {
+
+diff --git a/media/gpu/v4l2/v4l2_utils.h b/media/gpu/v4l2/v4l2_utils.h
+--- a/media/gpu/v4l2/v4l2_utils.h
++++ b/media/gpu/v4l2/v4l2_utils.h
+@@ -29,6 +29,26 @@
+ #define V4L2_PIX_FMT_INVALID v4l2_fourcc('0', '0', '0', '0')
+ #endif
+ 
++#ifndef V4L2_PIX_FMT_H264_SLICE
++#define V4L2_PIX_FMT_H264_SLICE v4l2_fourcc('S', '2', '6', '4')
++#endif
++
++#ifndef V4L2_PIX_FMT_HEVC_SLICE
++#define V4L2_PIX_FMT_HEVC_SLICE v4l2_fourcc('S', '2', '6', '5')
++#endif
++
++#ifndef V4L2_PIX_FMT_VP8_FRAME
++#define V4L2_PIX_FMT_VP8_FRAME v4l2_fourcc('V', 'P', '8', 'F')
++#endif
++
++#ifndef V4L2_PIX_FMT_VP9_FRAME
++#define V4L2_PIX_FMT_VP9_FRAME v4l2_fourcc('V', 'P', '9', 'F')
++#endif
++
++#ifndef V4L2_PIX_FMT_AV1_FRAME
++#define V4L2_PIX_FMT_AV1_FRAME v4l2_fourcc('A', 'V', '1', 'F')
++#endif
++
+ namespace gfx {
+ class Size;
+ }
+
+diff --git a/media/gpu/v4l2/v4l2_vda_helpers.cc b/media/gpu/v4l2/v4l2_vda_helpers.cc
+--- a/media/gpu/v4l2/v4l2_vda_helpers.cc
++++ b/media/gpu/v4l2/v4l2_vda_helpers.cc
+@@ -156,6 +156,8 @@
+     case VideoCodec::kH264:
+       return std::make_unique<
+           v4l2_vda_helpers::H264InputBufferFragmentSplitter>();
++    case VideoCodec::kAV1:
++      // HACK: Use the default implementation for AV1.
+     case VideoCodec::kVP8:
+     case VideoCodec::kVP9:
+       // VP8/VP9 don't need any frame splitting, use the default implementation.
+
+diff --git a/media/gpu/v4l2/v4l2_video_decoder.cc b/media/gpu/v4l2/v4l2_video_decoder.cc
+--- a/media/gpu/v4l2/v4l2_video_decoder.cc
++++ b/media/gpu/v4l2/v4l2_video_decoder.cc
+@@ -73,11 +73,13 @@
+ 
+ // Input format V4L2 fourccs this class supports.
+ const std::vector<uint32_t> kSupportedInputFourccs = {
++#if BUILDFLAG(IS_CHROMEOS)
+     // V4L2 stateless formats
+     V4L2_PIX_FMT_H264_SLICE,
+ #if BUILDFLAG(ENABLE_HEVC_PARSER_AND_HW_DECODER)
+     V4L2_PIX_FMT_HEVC_SLICE,
+ #endif  // BUILDFLAG(ENABLE_HEVC_PARSER_AND_HW_DECODER)
++#endif
+     V4L2_PIX_FMT_VP8_FRAME,
+     V4L2_PIX_FMT_VP9_FRAME,
+     V4L2_PIX_FMT_AV1_FRAME,
+@@ -467,6 +469,7 @@
+              << " and fourcc: " << FourccToString(input_format_fourcc_);
+     backend_ = std::make_unique<V4L2StatefulVideoDecoderBackend>(
+         this, device_, profile_, color_space_, decoder_task_runner_);
++#if BUILDFLAG(IS_CHROMEOS)
+   } else {
+     DCHECK_EQ(preferred_api_and_format.first, kStateless);
+     VLOGF(1) << "Using a stateless API for profile: "
+@@ -475,6 +478,7 @@
+     backend_ = std::make_unique<V4L2StatelessVideoDecoderBackend>(
+         this, device_, profile_, color_space_, decoder_task_runner_,
+         cdm_context_ref_ ? cdm_context_ref_->GetCdmContext() : nullptr);
++#endif
+   }
+ 
+   if (!backend_->Initialize()) {
+@@ -765,6 +769,7 @@
+ }
+ 
+ CroStatus V4L2VideoDecoder::SetExtCtrls10Bit(const gfx::Size& size) {
++#if BUILDFLAG(IS_CHROMEOS)
+   std::vector<struct v4l2_ext_control> ctrls;
+   struct v4l2_ctrl_hevc_sps v4l2_sps;
+   struct v4l2_ctrl_vp9_frame v4l2_vp9_frame;
+@@ -839,6 +844,9 @@
+   }
+ 
+   return CroStatus::Codes::kOk;
++#else
++  return CroStatus::Codes::kNoDecoderOutputFormatCandidates;
++#endif
+ }
+ 
+ void V4L2VideoDecoder::Reset(base::OnceClosure closure) {

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0002-HACK-media-gpu-v4l2-Enable-V4L2-VEA.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0002-HACK-media-gpu-v4l2-Enable-V4L2-VEA.patch
@@ -1,0 +1,37 @@
+From 12ee5f5708e39dadb09a92dc8c10b5412136fd54 Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Mon, 13 Feb 2023 15:30:55 +0800
+Subject: [PATCH 02/16] HACK: media: gpu: v4l2: Enable V4L2 VEA
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/media/gpu/gpu_video_encode_accelerator_factory.cc b/media/gpu/gpu_video_encode_accelerator_factory.cc
+--- a/media/gpu/gpu_video_encode_accelerator_factory.cc
++++ b/media/gpu/gpu_video_encode_accelerator_factory.cc
+@@ -57,7 +57,8 @@
+ namespace {
+ #if BUILDFLAG(USE_V4L2_CODEC)
+ std::unique_ptr<VideoEncodeAccelerator> CreateV4L2VEA() {
+-#if BUILDFLAG(IS_CHROMEOS)
++/* HACK: Enable V4L2 VEA for v4l-rkmpp */
++#if 1 // BUILDFLAG(IS_CHROMEOS)
+   // TODO(crbug.com/901264): Encoders use hack for passing offset within
+   // a DMA-buf, which is not supported upstream.
+   return base::WrapUnique<VideoEncodeAccelerator>(
+
+diff --git a/media/gpu/v4l2/BUILD.gn b/media/gpu/v4l2/BUILD.gn
+--- a/media/gpu/v4l2/BUILD.gn
++++ b/media/gpu/v4l2/BUILD.gn
+@@ -77,7 +77,12 @@
+       # AV1 delegate depends on header files only in ChromeOS SDK
+       "v4l2_video_decoder_delegate_av1.cc",
+       "v4l2_video_decoder_delegate_av1.h",
++    ]
++  }
+ 
++  # HACK: Enable V4L2 VEA for v4l-rkmpp.
++  if (true) {
++    sources += [
+       # TODO(crbug.com/901264): Encoders use hack for passing offset
+       # within a DMA-buf, which is not supported upstream.
+       "v4l2_video_encode_accelerator.cc",

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0003-media-gpu-v4l2-Gen-libv4l2_stubs.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0003-media-gpu-v4l2-Gen-libv4l2_stubs.patch
@@ -1,0 +1,29 @@
+From 05f496f2835cf108e00f720f81d6c6aa4146af3f Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Thu, 2 Nov 2023 16:08:22 +0800
+Subject: [PATCH 03/16] media: gpu: v4l2: Gen libv4l2_stubs
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/media/gpu/v4l2/BUILD.gn b/media/gpu/v4l2/BUILD.gn
+--- a/media/gpu/v4l2/BUILD.gn
++++ b/media/gpu/v4l2/BUILD.gn
+@@ -7,10 +7,18 @@
+ import("//media/gpu/args.gni")
+ import("//media/media_options.gni")
+ import("//testing/test.gni")
++import("//tools/generate_stubs/rules.gni")
+ import("//ui/gl/features.gni")
+ 
+ assert(use_v4l2_codec)
+ 
++generate_stubs("libv4l2_stubs") {
++  extra_header = "v4l2_stub_header.fragment"
++  sigs = [ "v4l2.sig" ]
++  output_name = "v4l2_stubs"
++  deps = [ "//base" ]
++}
++
+ source_set("v4l2") {
+   defines = [ "MEDIA_GPU_IMPLEMENTATION" ]
+   sources = [

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0004-media-gpu-v4l2-Support-libv4l2-plugins.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0004-media-gpu-v4l2-Support-libv4l2-plugins.patch
@@ -1,0 +1,198 @@
+From dff95574168f5f3a628d2a4f156fbc4959cdd1a2 Mon Sep 17 00:00:00 2001
+From: Damian Hobson-Garcia <dhobsong@igel.co.jp>
+Date: Wed, 21 Mar 2018 13:18:17 +0200
+Subject: [PATCH 04/16] media: gpu: v4l2: Support libv4l2 plugins
+
+Depends on custom libv4l2 with mmap & munmap.
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/media/gpu/v4l2/v4l2.sig b/media/gpu/v4l2/v4l2.sig
+--- a/media/gpu/v4l2/v4l2.sig
++++ b/media/gpu/v4l2/v4l2.sig
+@@ -8,3 +8,5 @@
+ LIBV4L_PUBLIC int v4l2_close(int fd);
+ LIBV4L_PUBLIC int v4l2_ioctl(int fd, unsigned long int request, ...);
+ LIBV4L_PUBLIC int v4l2_fd_open(int fd, int v4l2_flags);
++LIBV4L_PUBLIC void *v4l2_mmap(void *start, size_t length, int prot, int flags, int fd, int64_t offset);
++LIBV4L_PUBLIC int v4l2_munmap(void *_start, size_t length);
+
+diff --git a/media/gpu/v4l2/v4l2_device.cc b/media/gpu/v4l2/v4l2_device.cc
+--- a/media/gpu/v4l2/v4l2_device.cc
++++ b/media/gpu/v4l2/v4l2_device.cc
+@@ -40,6 +40,21 @@
+ #include "media/gpu/v4l2/v4l2_queue.h"
+ #include "media/gpu/v4l2/v4l2_utils.h"
+ 
++// Auto-generated for dlopen libv4l2 libraries
++#include "media/gpu/v4l2/v4l2_stubs.h"
++#include "third_party/v4l-utils/lib/include/libv4l2.h"
++
++using media_gpu_v4l2::InitializeStubs;
++using media_gpu_v4l2::kModuleV4l2;
++using media_gpu_v4l2::StubPathMap;
++
++inline static constexpr char kLibV4l2Path[] =
++#if defined(__aarch64__)
++      "/usr/lib64/libv4l2.so";
++#else
++      "/usr/lib/libv4l2.so";
++#endif
++
+ namespace media {
+ 
+ namespace {
+@@ -85,6 +100,7 @@
+ 
+ V4L2Device::V4L2Device() {
+   DETACH_FROM_SEQUENCE(client_sequence_checker_);
++  use_libv4l2_ = false;
+ }
+ 
+ V4L2Device::~V4L2Device() {
+@@ -328,6 +344,10 @@
+ 
+ int V4L2Device::Ioctl(int request, void* arg) {
+   DCHECK(device_fd_.is_valid());
++
++  if (use_libv4l2_)
++    return HANDLE_EINTR(v4l2_ioctl(device_fd_.get(), request, arg));
++
+   return HANDLE_EINTR(ioctl(device_fd_.get(), request, arg));
+ }
+ 
+@@ -362,10 +382,16 @@
+                        int flags,
+                        unsigned int offset) {
+   DCHECK(device_fd_.is_valid());
++  if (use_libv4l2_)
++    return v4l2_mmap(addr, len, prot, flags, device_fd_.get(), offset);
+   return mmap(addr, len, prot, flags, device_fd_.get(), offset);
+ }
+ 
+ void V4L2Device::Munmap(void* addr, unsigned int len) {
++  if (use_libv4l2_) {
++    v4l2_munmap(addr, len);
++    return;
++  }
+   munmap(addr, len);
+ }
+ 
+@@ -848,11 +874,29 @@
+ 
+   device_fd_.reset(
+       HANDLE_EINTR(open(path.c_str(), O_RDWR | O_NONBLOCK | O_CLOEXEC)));
+-  return device_fd_.is_valid();
++  if (!device_fd_.is_valid())
++    return false;
++
++  StubPathMap paths;
++  paths[kModuleV4l2].push_back(kLibV4l2Path);
++
++  static bool libv4l2_initialized = InitializeStubs(paths);
++  if (!libv4l2_initialized) {
++    VLOGF(1) << "Failed to initialize LIBV4L2 libs";
++  } else {
++    if (HANDLE_EINTR(v4l2_fd_open(device_fd_.get(), V4L2_DISABLE_CONVERSION)) !=
++            -1) {
++      DVLOGF(3) << "Using libv4l2 for " << path;
++      use_libv4l2_ = true;
++    }
++  }
++  return true;
+ }
+ 
+ void V4L2Device::CloseDevice() {
+   DVLOGF(3);
++  if (use_libv4l2_ && device_fd_.is_valid())
++    v4l2_close(device_fd_.release());
+   device_fd_.reset();
+ }
+ 
+
+diff --git a/media/gpu/v4l2/v4l2_device.h b/media/gpu/v4l2/v4l2_device.h
+--- a/media/gpu/v4l2/v4l2_device.h
++++ b/media/gpu/v4l2/v4l2_device.h
+@@ -280,6 +280,9 @@
+   // Callback to use for allocating secure buffers.
+   AllocateSecureBufferAsCallback secure_allocate_cb_;
+ 
++  // Use libv4l2 when operating |device_fd_|.
++  bool use_libv4l2_;
++
+   SEQUENCE_CHECKER(client_sequence_checker_);
+ };
+ 
+
+diff --git a/media/gpu/v4l2/v4l2_utils.cc b/media/gpu/v4l2/v4l2_utils.cc
+--- a/media/gpu/v4l2/v4l2_utils.cc
++++ b/media/gpu/v4l2/v4l2_utils.cc
+@@ -59,8 +59,27 @@
+ };
+ #endif
+ 
++// Auto-generated for dlopen libv4l2 libraries
++#include "media/gpu/v4l2/v4l2_stubs.h"
++#include "third_party/v4l-utils/lib/include/libv4l2.h"
++
++using media_gpu_v4l2::InitializeStubs;
++using media_gpu_v4l2::kModuleV4l2;
++using media_gpu_v4l2::StubPathMap;
++
++inline static constexpr char kLibV4l2Path[] =
++#if defined(__aarch64__)
++      "/usr/lib64/libv4l2.so";
++#else
++      "/usr/lib/libv4l2.so";
++#endif
++
++static bool use_libv4l2_ = false;
++
+ namespace {
+ int HandledIoctl(int fd, int request, void* arg) {
++  if (use_libv4l2_)
++    return HANDLE_EINTR(v4l2_ioctl(fd, request, arg));
+   return HANDLE_EINTR(ioctl(fd, request, arg));
+ }
+ 
+@@ -597,6 +616,13 @@
+   }
+ #endif
+ 
++  StubPathMap paths;
++  paths[kModuleV4l2].push_back(kLibV4l2Path);
++
++  static bool libv4l2_initialized = InitializeStubs(paths);
++  if (!libv4l2_initialized)
++    VLOGF(1) << "Failed to initialize LIBV4L2 libs";
++
+   for (const auto& path : candidate_paths) {
+     base::ScopedFD device_fd(
+         HANDLE_EINTR(open(path.c_str(), O_RDWR | O_NONBLOCK | O_CLOEXEC)));
+@@ -605,6 +631,15 @@
+       continue;
+     }
+ 
++    use_libv4l2_ = false;
++    if (libv4l2_initialized) {
++      if (HANDLE_EINTR(v4l2_fd_open(device_fd.get(), V4L2_DISABLE_CONVERSION)) !=
++          -1) {
++        DVLOGF(3) << "Using libv4l2 for " << path;
++        use_libv4l2_ = true;
++      }
++    }
++
+     std::vector<uint32_t> v4l2_codecs = EnumerateSupportedPixFmts(
+         base::BindRepeating(&HandledIoctl, device_fd.get()),
+         V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE);
+@@ -631,6 +666,10 @@
+             /*require_encrypted=*/false));
+       }
+     }
++
++    if (use_libv4l2_ && device_fd.is_valid())
++      v4l2_close(device_fd.release());
++    device_fd.reset();
+   }
+ 
+ #if DCHECK_IS_ON()

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0005-media-capture-linux-Support-libv4l2-plugins.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0005-media-capture-linux-Support-libv4l2-plugins.patch
@@ -1,0 +1,170 @@
+From a41ce0bd04785468108523547adc2f39de0e8f8f Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Mon, 1 Jul 2019 10:37:35 +0800
+Subject: [PATCH 05/16] media: capture: linux: Support libv4l2 plugins
+
+Allow using libv4l2 plugins for linux v4l2 capture devices.
+
+Depends on custom libv4l2 with mmap & munmap.
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/media/capture/BUILD.gn b/media/capture/BUILD.gn
+--- a/media/capture/BUILD.gn
++++ b/media/capture/BUILD.gn
+@@ -2,6 +2,7 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
++import("//build/buildflag_header.gni")
+ import("//build/config/apple/mobile_config.gni")
+ import("//build/config/features.gni")
+ import("//build/config/ui.gni")
+@@ -20,6 +21,14 @@
+   ]
+ }
+ 
++buildflag_header("buildflags") {
++  header = "buildflags.h"
++
++  flags = [
++    "USE_LIBV4L2=$use_v4lplugin",
++  ]
++}
++
+ component("capture_switches") {
+   defines = [ "CAPTURE_IMPLEMENTATION" ]
+   sources = [
+@@ -265,6 +274,12 @@
+       ]
+     }
+     deps += [ "//gpu/command_buffer/client" ]
++
++    public_deps += [ ":buildflags" ]
++
++    if (use_v4lplugin) {
++      deps += [ "//media/gpu/v4l2:libv4l2_stubs" ]
++    }
+   }
+ 
+   if (is_linux) {
+
+diff --git a/media/capture/video/linux/v4l2_capture_device_impl.cc b/media/capture/video/linux/v4l2_capture_device_impl.cc
+--- a/media/capture/video/linux/v4l2_capture_device_impl.cc
++++ b/media/capture/video/linux/v4l2_capture_device_impl.cc
+@@ -10,19 +10,62 @@
+ #include <sys/poll.h>
+ #include <unistd.h>
+ 
++#if BUILDFLAG(USE_LIBV4L2)
++// Auto-generated for dlopen libv4l2 libraries
++#include "media/gpu/v4l2/v4l2_stubs.h"
++#include "third_party/v4l-utils/lib/include/libv4l2.h"
++
++using media_gpu_v4l2::kModuleV4l2;
++using media_gpu_v4l2::InitializeStubs;
++using media_gpu_v4l2::StubPathMap;
++
++inline static constexpr char kLibV4l2Path[] =
++#if defined(__aarch64__)
++      "/usr/lib64/libv4l2.so";
++#else
++      "/usr/lib/libv4l2.so";
++#endif
++#endif
++
+ namespace media {
+ 
+ V4L2CaptureDeviceImpl::~V4L2CaptureDeviceImpl() = default;
+ 
++V4L2CaptureDeviceImpl::V4L2CaptureDeviceImpl() {
++#if BUILDFLAG(USE_LIBV4L2)
++  use_libv4l2_ = false;
++#endif
++}
++
+ int V4L2CaptureDeviceImpl::open(const char* device_name, int flags) {
+-  return ::open(device_name, flags);
++  int fd = ::open64(device_name, flags);
++  if (fd < 0)
++    return fd;
++
++#if BUILDFLAG(USE_LIBV4L2)
++  StubPathMap paths;
++  paths[kModuleV4l2].push_back(kLibV4l2Path);
++
++  static bool libv4l2_initialized = InitializeStubs(paths);
++  if (libv4l2_initialized && v4l2_fd_open(fd, V4L2_DISABLE_CONVERSION) != -1)
++      use_libv4l2_ = true;
++#endif
++  return fd;
+ }
+ 
+ int V4L2CaptureDeviceImpl::close(int fd) {
++#if BUILDFLAG(USE_LIBV4L2)
++  if (use_libv4l2_)
++    return v4l2_close(fd);
++#endif
+   return ::close(fd);
+ }
+ 
+ int V4L2CaptureDeviceImpl::ioctl(int fd, int request, void* argp) {
++#if BUILDFLAG(USE_LIBV4L2)
++  if (use_libv4l2_)
++    return v4l2_ioctl(fd, request, argp);
++#endif
+   return ::ioctl(fd, request, argp);
+ }
+ 
+@@ -32,10 +75,18 @@
+                                   int flags,
+                                   int fd,
+                                   off_t offset) {
++#if BUILDFLAG(USE_LIBV4L2)
++  if (use_libv4l2_)
++    return v4l2_mmap(start, length, prot, flags, fd, offset);
++#endif
+   return ::mmap(start, length, prot, flags, fd, offset);
+ }
+ 
+ int V4L2CaptureDeviceImpl::munmap(void* start, size_t length) {
++#if BUILDFLAG(USE_LIBV4L2)
++  if (use_libv4l2_)
++    return v4l2_munmap(start, length);
++#endif
+   return ::munmap(start, length);
+ }
+ 
+
+diff --git a/media/capture/video/linux/v4l2_capture_device_impl.h b/media/capture/video/linux/v4l2_capture_device_impl.h
+--- a/media/capture/video/linux/v4l2_capture_device_impl.h
++++ b/media/capture/video/linux/v4l2_capture_device_impl.h
+@@ -8,6 +8,7 @@
+ #include <fcntl.h>
+ #include <poll.h>
+ 
++#include "media/capture/buildflags.h"
+ #include "media/capture/capture_export.h"
+ #include "media/capture/video/linux/v4l2_capture_device.h"
+ 
+@@ -17,6 +18,8 @@
+ // V4L2 APIs.
+ class CAPTURE_EXPORT V4L2CaptureDeviceImpl : public V4L2CaptureDevice {
+  public:
++  V4L2CaptureDeviceImpl();
++
+   int open(const char* device_name, int flags) override;
+   int close(int fd) override;
+   int ioctl(int fd, int request, void* argp) override;
+@@ -32,6 +35,11 @@
+ 
+  private:
+   ~V4L2CaptureDeviceImpl() override;
++
++#if BUILDFLAG(USE_LIBV4L2)
++  // Use libv4l2 when operating |fd|.
++  bool use_libv4l2_;
++#endif
+ };
+ 
+ }  // namespace media

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0006-cld3-Avoid-unaligned-accesses.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0006-cld3-Avoid-unaligned-accesses.patch
@@ -1,0 +1,39 @@
+From 904c848c33af37909e7dd4732a325d00d8dce19c Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Fri, 27 Mar 2020 17:48:20 +0800
+Subject: [PATCH 06/16] cld3: Avoid unaligned accesses
+
+Although the unaligned memory accesses are enabled, somehow i still hit
+the SIGBUS:
+[23496.643138] Unhandled fault: alignment fault (0x92000021) at 0x00000000b182e636
+Received signal 7 BUS_ADRALN 0000b182e636
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/third_party/cld_3/src/src/script_span/port.h b/third_party/cld_3/src/src/script_span/port.h
+--- a/third_party/cld_3/src/src/script_span/port.h
++++ b/third_party/cld_3/src/src/script_span/port.h
+@@ -78,11 +78,23 @@
+ //
+ // This is a mess, but there's not much we can do about it.
+ 
++#if 0
+ #define UNALIGNED_LOAD16(_p) (*reinterpret_cast<const uint16 *>(_p))
+ #define UNALIGNED_LOAD32(_p) (*reinterpret_cast<const uint32 *>(_p))
+ 
+ #define UNALIGNED_STORE16(_p, _val) (*reinterpret_cast<uint16 *>(_p) = (_val))
+ #define UNALIGNED_STORE32(_p, _val) (*reinterpret_cast<uint32 *>(_p) = (_val))
++#else
++inline uint32 UNALIGNED_LOAD32(const void *p) {
++  uint32 t;
++  memcpy(&t, p, sizeof t);
++  return t;
++}
++
++inline void UNALIGNED_STORE32(void *p, uint32 v) {
++  memcpy(p, &v, sizeof v);
++}
++#endif
+ 
+ // TODO(sesse): NEON supports unaligned 64-bit loads and stores.
+ // See if that would be more efficient on platforms supporting it,

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0007-media-gpu-v4l2-Use-POLLIN-for-pending-event.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0007-media-gpu-v4l2-Use-POLLIN-for-pending-event.patch
@@ -1,0 +1,26 @@
+From 61894c8795fc8a3cc9687dd67f89c7926f2bf853 Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Fri, 10 Apr 2020 16:16:08 +0800
+Subject: [PATCH 07/16] media: gpu: v4l2: Use POLLIN for pending event
+
+The v4l-rkmpp is using eventfd to fake poll events which not supporting
+POLLPRI.
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/media/gpu/v4l2/v4l2_device.cc b/media/gpu/v4l2/v4l2_device.cc
+--- a/media/gpu/v4l2/v4l2_device.cc
++++ b/media/gpu/v4l2/v4l2_device.cc
+@@ -372,7 +372,11 @@
+     VPLOGF(1) << "poll() failed";
+     return false;
+   }
+-  *event_pending = (pollfd != -1 && pollfds[pollfd].revents & POLLPRI);
++
++  // HACK: Could not fake POLLPRI with eventfd
++  // *event_pending = (pollfd != -1 && pollfds[pollfd].revents & POLLPRI);
++  *event_pending = (pollfd != -1 && pollfds[pollfd].revents & POLLIN);
++
+   return true;
+ }
+ 

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0008-media-capture-linux-Prefer-using-the-first-device.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0008-media-capture-linux-Prefer-using-the-first-device.patch
@@ -1,0 +1,26 @@
+From 3359ed17047d2b1458dd0c39c20ccd2dc0cb33a7 Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Thu, 5 Nov 2020 12:22:52 +0800
+Subject: [PATCH 08/16] media: capture: linux: Prefer using the first device
+
+Somehow the newest chromium would prefer using the last device in some
+cases, e.g. apprtc.
+
+Let's reverse the device array to workaround it.
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/media/capture/video/linux/video_capture_device_factory_v4l2.cc b/media/capture/video/linux/video_capture_device_factory_v4l2.cc
+--- a/media/capture/video/linux/video_capture_device_factory_v4l2.cc
++++ b/media/capture/video/linux/video_capture_device_factory_v4l2.cc
+@@ -208,7 +208,9 @@
+         continue;
+       }
+ 
+-      devices_info.emplace_back(VideoCaptureDeviceDescriptor(
++
++      // HACK: Somehow the newest chromium would prefer using the last device in some cases, e.g. apprtc
++      devices_info.emplace(devices_info.begin(), VideoCaptureDeviceDescriptor(
+           display_name, unique_id, model_id,
+           VideoCaptureApi::LINUX_V4L2_SINGLE_PLANE, GetControlSupport(fd.get()),
+           VideoCaptureTransportType::OTHER_TRANSPORT, facing_mode));

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0009-Create-new-fence-when-there-s-no-in-fences.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0009-Create-new-fence-when-there-s-no-in-fences.patch
@@ -1,0 +1,82 @@
+From d70972bd2f7bc7e86ef3559ad5f5487f14ec6436 Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Mon, 31 May 2021 01:29:11 +0800
+Subject: [PATCH 09/16] Create new fence when there's no in-fences
+
+There're cases that in-fences are not provided.
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+--- a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+@@ -35,6 +35,12 @@
+ // and remove the rest.
+ static constexpr size_t kMaxSolidColorBuffers = 12;
+ 
++void WaitForEGLFence(EGLDisplay display, EGLSyncKHR fence) {
++  eglClientWaitSyncKHR(display, fence, EGL_SYNC_FLUSH_COMMANDS_BIT_KHR,
++                       EGL_FOREVER_KHR);
++  eglDestroySyncKHR(display, fence);
++}
++
+ void WaitForGpuFences(std::vector<std::unique_ptr<gfx::GpuFence>> fences) {
+   for (auto& fence : fences)
+     fence->Wait();
+@@ -209,8 +215,9 @@
+     return;
+   }
+ 
+-  base::OnceClosure fence_wait_task;
+   std::vector<std::unique_ptr<gfx::GpuFence>> fences;
++  // Uset in-fences provided in the overlays. If there are none, we insert our
++  // own fence and wait.
+   for (auto& config : frame->configs) {
+     if (!config.access_fence_handle.is_null()) {
+       fences.push_back(std::make_unique<gfx::GpuFence>(
+@@ -219,7 +226,17 @@
+     }
+   }
+ 
+-  fence_wait_task = base::BindOnce(&WaitForGpuFences, std::move(fences));
++  base::OnceClosure fence_wait_task;
++  if (!fences.empty()) {
++    fence_wait_task = base::BindOnce(&WaitForGpuFences, std::move(fences));
++  } else {
++    // TODO(fangzhoug): the following should be replaced by a per surface flush
++    // as it gets implemented in GL drivers.
++    EGLSyncKHR fence = InsertFence(has_implicit_external_sync_);
++    CHECK_NE(fence, EGL_NO_SYNC_KHR) << "eglCreateSyncKHR failed";
++
++    fence_wait_task = base::BindOnce(&WaitForEGLFence, GetDisplay(), fence);
++  }
+ 
+   base::OnceClosure fence_retired_callback = base::BindOnce(
+       &GbmSurfacelessWayland::FenceRetired, weak_factory_.GetWeakPtr(), frame);
+@@ -292,6 +309,14 @@
+   }
+ }
+ 
++EGLSyncKHR GbmSurfacelessWayland::InsertFence(bool implicit) {
++  const EGLint attrib_list[] = {EGL_SYNC_CONDITION_KHR,
++                                EGL_SYNC_PRIOR_COMMANDS_IMPLICIT_EXTERNAL_ARM,
++                                EGL_NONE};
++  return eglCreateSyncKHR(GetEGLDisplay(), EGL_SYNC_FENCE_KHR,
++                          implicit ? attrib_list : nullptr);
++}
++
+ void GbmSurfacelessWayland::FenceRetired(PendingFrame* frame) {
+   frame->ready = true;
+   MaybeSubmitFrames();
+
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
+--- a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
++++ b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
+@@ -152,6 +152,7 @@
+ 
+   void MaybeSubmitFrames();
+ 
++  EGLSyncKHR InsertFence(bool implicit);
+   void FenceRetired(PendingFrame* frame);
+ 
+   // Sets a flag that skips glFlush step in unittests.

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0010-HACK-ozone-wayland-Force-disable-implicit-external-s.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0010-HACK-ozone-wayland-Force-disable-implicit-external-s.patch
@@ -1,0 +1,27 @@
+From 3064906c904c83e11fc64e37850016d1580701ee Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Mon, 31 May 2021 01:41:57 +0800
+Subject: [PATCH 10/16] HACK: [ozone/wayland]: Force disable implicit external
+ sync
+
+The Mali's implicit external sync seems broken.
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+--- a/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
++++ b/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+@@ -232,10 +232,11 @@
+   } else {
+     // TODO(fangzhoug): the following should be replaced by a per surface flush
+     // as it gets implemented in GL drivers.
+-    EGLSyncKHR fence = InsertFence(has_implicit_external_sync_);
++    // HACK: The Mali's implicit external sync seems broken.
++    EGLSyncKHR fence = InsertFence(/* has_implicit_external_sync_ */ false);
+     CHECK_NE(fence, EGL_NO_SYNC_KHR) << "eglCreateSyncKHR failed";
+ 
+-    fence_wait_task = base::BindOnce(&WaitForEGLFence, GetDisplay(), fence);
++    fence_wait_task = base::BindOnce(&WaitForEGLFence, GetEGLDisplay(), fence);
+   }
+ 
+   base::OnceClosure fence_retired_callback = base::BindOnce(

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0011-HACK-media-capture-linux-Allow-camera-without-suppor.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0011-HACK-media-capture-linux-Allow-camera-without-suppor.patch
@@ -1,0 +1,28 @@
+From d55ea76b14f50a6f46d5a8ef45a1047360ea959a Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Mon, 31 May 2021 07:25:58 +0800
+Subject: [PATCH 11/16] HACK: media: capture: linux: Allow camera without
+ supported format
+
+The chromium would only accept discrete frame sizes.
+
+Hack it to make Rockchip ISP camera working.
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/media/capture/video/linux/video_capture_device_factory_v4l2.cc b/media/capture/video/linux/video_capture_device_factory_v4l2.cc
+--- a/media/capture/video/linux/video_capture_device_factory_v4l2.cc
++++ b/media/capture/video/linux/video_capture_device_factory_v4l2.cc
+@@ -203,10 +203,8 @@
+ 
+       VideoCaptureFormats supported_formats;
+       GetSupportedFormatsForV4L2BufferType(fd.get(), &supported_formats);
+-      if (supported_formats.empty()) {
+-        DVLOG(1) << "No supported formats: " << unique_id;
+-        continue;
+-      }
++      if (supported_formats.empty())
++        LOG(WARNING) << "No supported formats: " << unique_id;
+ 
+ 
+       // HACK: Somehow the newest chromium would prefer using the last device in some cases, e.g. apprtc

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0012-content-gpu-Only-depend-dri-for-X11.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0012-content-gpu-Only-depend-dri-for-X11.patch
@@ -1,0 +1,19 @@
+From b7283b34e18b0ec0595aa67f6110e7e802f183fd Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Mon, 22 Nov 2021 15:59:49 +0800
+Subject: [PATCH 12/16] content: gpu: Only depend dri for X11
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/content/gpu/BUILD.gn b/content/gpu/BUILD.gn
+--- a/content/gpu/BUILD.gn
++++ b/content/gpu/BUILD.gn
+@@ -125,7 +125,7 @@
+ 
+   # Use DRI on desktop Linux builds.
+   if (current_cpu != "s390x" && current_cpu != "ppc64" && is_linux &&
+-      !is_castos) {
++      !is_castos && ozone_platform_x11) {
+     configs += [ "//build/config/linux/dri" ]
+   }
+ }

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0013-media-gpu-sandbox-Only-depend-dri-for-X11.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0013-media-gpu-sandbox-Only-depend-dri-for-X11.patch
@@ -1,0 +1,19 @@
+From 7d4201e573866edad35ed20092546e347674adc9 Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Mon, 20 Mar 2023 15:00:44 +0800
+Subject: [PATCH 13/16] media: gpu: sandbox: Only depend dri for X11
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/media/gpu/sandbox/BUILD.gn b/media/gpu/sandbox/BUILD.gn
+--- a/media/gpu/sandbox/BUILD.gn
++++ b/media/gpu/sandbox/BUILD.gn
+@@ -26,7 +26,7 @@
+     deps += [ "//media/gpu/v4l2" ]
+   }
+   if (current_cpu != "s390x" && current_cpu != "ppc64" && is_linux &&
+-      !is_castos) {
++      !is_castos && ozone_platform_x11) {
+     # For DRI_DRIVER_DIR.
+     configs += [ "//build/config/linux/dri" ]
+   }

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0014-ui-gfx-linux-Force-disabling-modifiers.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0014-ui-gfx-linux-Force-disabling-modifiers.patch
@@ -1,0 +1,22 @@
+From 6c6ce5d0f35238c5151f38ac24471b1d7bae3aa7 Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Mon, 7 Aug 2023 18:05:41 +0800
+Subject: [PATCH 14/16] ui: gfx: linux: Force disabling modifiers
+
+It crashes somehow.
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/ui/gfx/linux/gbm_wrapper.cc b/ui/gfx/linux/gbm_wrapper.cc
+--- a/ui/gfx/linux/gbm_wrapper.cc
++++ b/ui/gfx/linux/gbm_wrapper.cc
+@@ -308,7 +308,8 @@
+       const gfx::Size& requested_size,
+       uint32_t flags,
+       const std::vector<uint64_t>& modifiers) override {
+-    if (modifiers.empty()) {
++    // HACK: Force disabling modifiers
++    if (true || modifiers.empty()) {
+       return CreateBuffer(format, requested_size, flags);
+     }
+ 

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0015-HACK-ui-x11-Fix-config-choosing-error-with-Mali-DDK.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0015-HACK-ui-x11-Fix-config-choosing-error-with-Mali-DDK.patch
@@ -1,0 +1,33 @@
+From 1fb35b74fbc2ae932b6798ec58cadae390d6d7b6 Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Wed, 22 May 2024 18:45:56 +0800
+Subject: [PATCH 15/16] HACK: ui: x11: Fix config choosing error with Mali DDK
+
+The Mali DDK only reports EGL configs for the first compatible visual,
+whereas Chromium would choose a random compatible visual.
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/ui/gl/gl_surface_egl_x11.cc b/ui/gl/gl_surface_egl_x11.cc
+--- a/ui/gl/gl_surface_egl_x11.cc
++++ b/ui/gl/gl_surface_egl_x11.cc
+@@ -71,10 +71,19 @@
+ }
+ 
+ EGLint NativeViewGLSurfaceEGLX11::GetNativeVisualID() const {
++/**
++ * HACK: Ignore native visual ID, because the Mali DDK only reports EGL
++ * configs for the first compatible visual, whereas Chromium would choose
++ * a random compatible visual.
++ */
++#if 0
+   x11::VisualId visual_id;
+   GetXNativeConnection()->GetOrCreateVisualManager().ChooseVisualForWindow(
+       true, &visual_id, nullptr, nullptr, nullptr);
+   return static_cast<EGLint>(visual_id);
++#else
++  return -1;
++#endif
+ }
+ 
+ NativeViewGLSurfaceEGLX11::~NativeViewGLSurfaceEGLX11() {

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0016-ui-ozone-wayland-Prefer-rockchip-drm-render-node.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0016-ui-ozone-wayland-Prefer-rockchip-drm-render-node.patch
@@ -1,0 +1,21 @@
+From 3ac3467c5bb7f13989f59ad369a6b46932384bff Mon Sep 17 00:00:00 2001
+From: Caesar Wang <wxt@rock-chips.com>
+Date: Fri, 12 Sep 2025 16:58:06 +0800
+Subject: [PATCH 16/16] ui: ozone: wayland: Prefer rockchip drm render node
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/ui/ozone/platform/wayland/common/drm_render_node_path_finder.cc b/ui/ozone/platform/wayland/common/drm_render_node_path_finder.cc
+--- a/ui/ozone/platform/wayland/common/drm_render_node_path_finder.cc
++++ b/ui/ozone/platform/wayland/common/drm_render_node_path_finder.cc
+@@ -100,8 +100,8 @@
+     return;
+   }
+ 
+-  static constexpr const char* preferred_drivers[3] = {"i915", "amdgpu",
+-                                                       "virtio_gpu"};
++  static constexpr const char* preferred_drivers[4] = {"i915", "amdgpu",
++                                                       "virtio_gpu", "rockchip"};
+   for (const char* preferred_driver : preferred_drivers) {
+     for (const auto& [driver, node] : driver_to_nodes) {
+       if (driver == preferred_driver) {

--- a/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0017-media-gpu-chromeos-Fix-SIGTRAP-during-dynamic-video-.patch
+++ b/dynamic-layers/recipes-browser/chromium/chromium_138.0.7204/0017-media-gpu-chromeos-Fix-SIGTRAP-during-dynamic-video-.patch
@@ -1,0 +1,22 @@
+From 6e101dcd2654ca8b52f086d088fb40c4c1d5bb10 Mon Sep 17 00:00:00 2001
+From: Jeffy Chen <jeffy.chen@rock-chips.com>
+Date: Tue, 10 Feb 2026 18:19:58 +0800
+Subject: [PATCH] media: gpu: chromeos: Fix SIGTRAP during dynamic video
+ resolution switching
+
+Signed-off-by: Jeffy Chen <jeffy.chen@rock-chips.com>
+---
+diff --git a/media/gpu/chromeos/video_decoder_pipeline.cc b/media/gpu/chromeos/video_decoder_pipeline.cc
+--- a/media/gpu/chromeos/video_decoder_pipeline.cc
++++ b/media/gpu/chromeos/video_decoder_pipeline.cc
+@@ -665,7 +665,9 @@
+     return;
+   }
+ 
+-  if (frame_converter_->UsesGetOriginalFrameCB()) {
++  // HACK: Workaround for CHECK(main_frame_pool_) failure during reinit.
++  // if (frame_converter_->UsesGetOriginalFrameCB()) {
++  if (main_frame_pool_ && frame_converter_->UsesGetOriginalFrameCB()) {
+     FrameResourceConverter::GetOriginalFrameCB get_original_frame_cb;
+ 
+     if (uses_oop_video_decoder_) {


### PR DESCRIPTION
re-applied chromium 132 patches for chromium 138.

Compiled with

```
yocto 5.0.18

meta                 
meta-poky            
meta-yocto-bsp       = "HEAD:44dcf08572ce391d7c0df4f8c7510af5e096baca"

meta-oe              
meta-networking      
meta-multimedia      
meta-python          
meta-webserver       = "HEAD:d8cc4e44001c7257273d290ce8c4496e93d32841"

meta-clang           = "HEAD:76596813cd0061bd9818a80926e6900af61fcaa0"
meta-lts-mixins-rust = "HEAD:96deb45139df027473faf0938fe006d33c45c375"
meta-chromium        = "HEAD:d4c6ed09cd724c25648f6cb4a02a350d7423a5a1"
```

Noticed that chromium-gn.inc also needs following patch:

```
diff --git a/meta-chromium/recipes-browser/chromium/chromium-gn.inc b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
index 4d8c3272..9640b047 100644
--- a/meta-chromium/recipes-browser/chromium/chromium-gn.inc
+++ b/meta-chromium/recipes-browser/chromium/chromium-gn.inc
@@ -508,7 +508,14 @@ addtask copy_clang_library after do_add_clang_latest before do_compile
 do_copy_target_rustlibs () {
     # Chromium needs a single Rust sysroot that contains the rustlibs for both
     # the host and target, so we copy the target rustlibs to the native sysroot.
+    # Remove old rlibs/rmeta first to avoid duplicates from rust-cross vs
+    # libstd-rs causing symbol hash mismatches at link time.
+    # Use RUST_TARGET_SYS (not TARGET_ARCH*) to avoid nuking host rlibs.
     rustlib_src_dir="${STAGING_LIBDIR}/rustlib/${TARGET_ARCH}"*
+    if [ -d "${STAGING_LIBDIR_NATIVE}/rustlib/${RUST_TARGET_SYS}/lib" ]; then
+        rm -f "${STAGING_LIBDIR_NATIVE}/rustlib/${RUST_TARGET_SYS}/lib"/*.rlib
+        rm -f "${STAGING_LIBDIR_NATIVE}/rustlib/${RUST_TARGET_SYS}/lib"/*.rmeta
+    fi
     cp -r $rustlib_src_dir "${STAGING_LIBDIR_NATIVE}/rustlib"
 }
 addtask copy_target_rustlibs after do_configure before do_compile
```

Should I onboard this patch too?