### PR TITLE
rockchip-image: Return 0 from the early-exit guards

### DIFF
--- a/classes/rockchip-image.bbclass
+++ b/classes/rockchip-image.bbclass
@@ -57,7 +57,7 @@ do_fixup_wks[depends] += " \
 	virtual/bootloader:do_deploy \
 "
 do_fixup_wks() {
-	[ -f "${WKS_FULL_PATH}" ] || return
+	[ -f "${WKS_FULL_PATH}" ] || return 0
 
 	IMAGES=$(grep -o "[^=]*\.img" "${WKS_FULL_PATH}")
 
@@ -74,7 +74,7 @@ IMAGE_POSTPROCESS_COMMAND:append = " do_image_wic_ufs;gen_rkparameter;"
 
 do_image_wic_ufs() {
 	IMAGE="${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.wic"
-	[ -f "${IMAGE}" ] || return
+	[ -f "${IMAGE}" ] || return 0
 
 	echo "Creating wic image for UFS(4K logical sector size)..."
 


### PR DESCRIPTION
Both early-exit guards return 1 instead of 0, because a bare `return` propagates the exit
status of the failing `[ -f ... ]` test. Since `do_image_wic_ufs` is appended to
`IMAGE_POSTPROCESS_COMMAND`, any image built without a `.wic` fails `do_image_complete`.

Reproduced on scarthgap, with the layer enabled the way the README documents:

```
# local.conf
MACHINE = "rockchip-rk3588-evb"
INHERIT:append = " rockchip-image"
IMAGE_FSTYPES:remove = "wic"
```

```
$ bitbake core-image-minimal
ERROR: core-image-minimal-1.0-r0 do_image_complete: ExecutionError(
    '.../core-image-minimal/1.0/temp/run.do_image_wic_ufs.2440058', 1, None, None)
ERROR: Task (.../core-image-minimal.bb:do_image_complete) failed with exit code '1'
NOTE: Tasks Summary: Attempted 3248 tasks of which 2105 didn't need to be rerun and 1 failed.
```

The task log shows `link_rootfs_image` running, `do_image_wic_ufs` exiting 1, and
`gen_rkparameter` / `gen_rkupdateimg` / `link_latest_image` never being reached.

With this patch applied and nothing else changed, the same build completes:

```
NOTE: recipe core-image-minimal-1.0-r0: task do_image_complete: Succeeded
NOTE: Tasks Summary: Attempted 3250 tasks of which 3247 didn't need to be rerun and all succeeded.
```

`:remove` is required to reach this. The class does
`IMAGE_FSTYPES:append = " ${RK_ROOTFS_TYPE} wic"`, applied after a recipe's own assignment,
so `IMAGE_FSTYPES = "cpio.gz"` still expands to `cpio.gz ext4 wic` and a `.wic` is produced.

`do_fixup_wks` is narrower: it is only pulled in when wic is in use, so its guard fires when
no kickstart file is found for `WKS_FILE`, masking wic's own error message.
